### PR TITLE
BuildICON.cmake: Only add '--enable-oascoupling' option in coupled mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ find_package(MPIFortran REQUIRED)
 if(DEFINED OASIS_SRC)
   include(BuildOASIS3MCT)
   list(APPEND MODEL_DEPENDENCIES OASIS3_MCT)
-else()
-  message(WARNING "OASIS_SRC was not specified.")
 endif()
 
 # TODO (for all Build*.cmake scripts):

--- a/cmake/BuildICON.cmake
+++ b/cmake/BuildICON.cmake
@@ -38,7 +38,10 @@ list(APPEND ICON_LIBS "${NetCDF_LIBRARIES}")
 
 list(JOIN ICON_LIBS " " ICON_LIBS)
 
-list(APPEND EXTRA_CONFIG_ARGS --disable-coupling --disable-ocean --disable-jsbach --enable-oascoupling --enable-ecrad --enable-parallel-netcdf)
+list(APPEND EXTRA_CONFIG_ARGS --disable-coupling --disable-ocean --disable-jsbach --enable-ecrad --enable-parallel-netcdf)
+if(DEFINED eCLM_SRC OR DEFINED CLM35_SRC)
+  list(APPEND EXTRA_CONFIG_ARGS --enable-oascoupling)
+endif()
 
 ExternalProject_Add(ICON
     PREFIX            ICON


### PR DESCRIPTION
Fixes #19 