### PR TITLE
Do not clean OASIS when not asked for

### DIFF
--- a/cmake/BuildOASIS3MCT.cmake
+++ b/cmake/BuildOASIS3MCT.cmake
@@ -61,7 +61,7 @@ ExternalProject_Add(OASIS3_MCT
   SOURCE_DIR        ${OASIS_SRC}
   BUILD_IN_SOURCE   FALSE
   CONFIGURE_COMMAND ""
-  BUILD_COMMAND     make -f ${OASIS_SRC}/util/make_dir/TopMakefileOasis3 realclean static-libs -C ${OASIS_BLD_DIR}
+  BUILD_COMMAND     make -f ${OASIS_SRC}/util/make_dir/TopMakefileOasis3 static-libs -C ${OASIS_BLD_DIR}
   INSTALL_COMMAND   ""
 )
 


### PR DESCRIPTION
This reduces compilation wall time by a couple of minutes.

You can insist on a clean by using the `--clean-first` CMake command line option (it's mentioned by example in the README).