### PR TITLE
Update setting of PDAF optimization flags

### DIFF
--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -73,12 +73,48 @@ list(JOIN PDAF_LINK_LIBS " " PDAF_LINK_LIBS)
 
 # Set PDAF_OPTIM for Makefile header
 # ----------------------------------
-list(APPEND PDAF_OPTIM "-O2")
-list(APPEND PDAF_OPTIM "-xHost")
-list(APPEND PDAF_OPTIM "-r8")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 
-# For Gnu-compiler
-# list(APPEND PDAF_OPTIM "-O2 -xHost -fbacktrace -fdefault-real-8 -falign-commons -fno-automatic -finit-local-zero -mcmodel=large")
+  # using Intel Compiler
+  if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    # Release optimization flags
+    list(APPEND PDAF_OPTIM "-O2")
+  elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+    # Debug optimization flags
+    list(APPEND PDAF_OPTIM "-O0")
+    list(APPEND PDAF_OPTIM "-g")
+    list(APPEND PDAF_OPTIM "-traceback")
+  else()
+    message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+
+  list(APPEND PDAF_OPTIM "-xHost")
+  list(APPEND PDAF_OPTIM "-r8")
+
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+
+  # using GCC (experimental)
+  if (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    # Release optimization flags
+    list(APPEND PDAF_OPTIM "-O2")
+  elseif (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+    # Debug optimization flags
+    list(APPEND PDAF_OPTIM "-O0")
+    list(APPEND PDAF_OPTIM "-g")
+    list(APPEND PDAF_OPTIM "-fbacktrace")
+  else()
+    message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+
+  list(APPEND PDAF_OPTIM "-fdefault-real-8")
+  list(APPEND PDAF_OPTIM "-falign-commons")
+  list(APPEND PDAF_OPTIM "-fno-automatic")
+  list(APPEND PDAF_OPTIM "-finit-local-zero")
+  list(APPEND PDAF_OPTIM "-mcmodel=large")
+
+else()
+  message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
+endif()
 
 # Join list
 list(JOIN PDAF_OPTIM " " PDAF_OPTIM)


### PR DESCRIPTION
Adapt flags according to

1. `CMAKE_CXX_COMPILER_ID` (`Intel` or `GNU`)

2. `CMAKE_BUILD_TYPE` (`RELEASE` or `DEBUG`)

Flags are taken from TSMP1:
- https://github.com/HPSCTerrSys/TSMP/blob/c67201d195ea58e4913ef065b1105ea0ce24ab0a/bldsva/machines/config_JURECA.ksh#L35-L42
- https://github.com/HPSCTerrSys/TSMP/blob/c67201d195ea58e4913ef065b1105ea0ce24ab0a/bldsva/intf_DA/pdaf/arch/build_interface_pdaf.ksh#L51