### PR TITLE
Add MIT License in LICENSE.txt and CONTRIBUTORS.txt

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,13 @@
+Paul RIGOR
+Stefan KOLLET
+Niklas WAGNER
+Lukas STREBEL
+Haojin ZHAO
+Klaus GOERGEN
+Stefan POLL
+Johannes KELLER
+Daniel CAVIEDES-VOULLIEME
+Ilya ZHUKOV
+Joerg BENKE
+Carl HARTICK
+Marco VAN HULTEN

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,13 +1,13 @@
-Paul RIGOR
 Stefan KOLLET
-Niklas WAGNER
-Lukas STREBEL
-Haojin ZHAO
-Klaus GOERGEN
+Paul RIGOR
 Stefan POLL
 Johannes KELLER
 Daniel CAVIEDES-VOULLIEME
-Ilya ZHUKOV
 Joerg BENKE
+Klaus GOERGEN
 Carl HARTICK
+Lukas STREBEL
 Marco VAN HULTEN
+Niklas WAGNER
+Haojin ZHAO
+Ilya ZHUKOV

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2023-2024 by the TSMP2 Team (see the CONTRIBUTORS.txt file)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.


### PR DESCRIPTION
See Issue  #25 

If we all agree that MIT License is the way to go, the main point for changes should be the content of the `CONTRIBUTORS.txt` (more names, remove names, possibly add affiliation).

Moreover, `CONTRIBUTORS.txt` will be subject to change as new contributors arrive.