### PR TITLE
build_tsmp2.sh: `--build_config` input in capital letters

### DIFF
--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -25,7 +25,7 @@ function help_tsmp2() {
   echo "  --ParFlow_SRC    Set ParFlow_SRC directory"
   echo "  --OASIS_SRC      Set OASIS3-MCT directory"
   echo "  --PDAF_SRC       Set PDAF_SRC directory"
-  echo "  --build_config   Set build configuration: 'Debug' 'Release'"
+  echo "  --build_config   Set build configuration: 'DEBUG' 'RELEASE'"
   echo "  --compiler       Set compiler for building"
   echo "  --build_dir      Set build dir cmake, if not set bld/<SYSTEMNAME>_<model-id> is used. Build artifacts will be generated in this folder."
   echo "  --install_dir    Set install dir cmake, if not set bin/<SYSTEMNAME>_<model-id> is used. Model executables and libraries will be installed here"


### PR DESCRIPTION
In the help for `build_tsmp2.ksh` input `--build_config`, I move the inputs to capital letters.

For input `--build_config Debug`, we get a "not supported error" from `BuildPDAF.cmake`: 

https://github.com/HPSCTerrSys/TSMP2/blob/2a3e8a103ebcbb11da6791b7574008b5bd9f81cd/cmake/BuildPDAF.cmake#L79-L89

Similar error message exists for OASIS. So I think currently it would be best to always ask for capital letters `DEBUG` or `RELEASE`, but we could have another discussion whether to change this!