### PR TITLE
BuildPDAF: Add CMake envvar `TSMPPDAFDOUBLEPRECISION`

### DIFF
--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -89,7 +89,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   endif()
 
   list(APPEND PDAF_OPTIM "-xHost")
-  list(APPEND PDAF_OPTIM "-r8")
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
@@ -106,7 +105,6 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
   endif()
 
-  list(APPEND PDAF_OPTIM "-fdefault-real-8")
   list(APPEND PDAF_OPTIM "-falign-commons")
   list(APPEND PDAF_OPTIM "-fno-automatic")
   list(APPEND PDAF_OPTIM "-finit-local-zero")
@@ -118,6 +116,23 @@ endif()
 
 # Join list
 list(JOIN PDAF_OPTIM " " PDAF_OPTIM)
+
+# Set PDAF_DOUBLEPRECISION for Makefile header
+# --------------------------------------------
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+
+  list(APPEND PDAF_DOUBLEPRECISION "-r8")
+
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+
+  list(APPEND PDAF_DOUBLEPRECISION "-fdefault-real-8")
+
+else()
+  message(FATAL_ERROR "Unsupported CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+# Join list
+list(JOIN PDAF_DOUBLEPRECISION " " PDAF_DOUBLEPRECISION)
 
 # Set PDAF_MPI_INC for Makefile header
 # ----------------------------------
@@ -144,6 +159,7 @@ list(APPEND PDAF_ENV_VARS PDAF_ARCH=${PDAF_ARCH})
 list(APPEND PDAF_ENV_VARS PDAF_DIR=${PDAF_DIR})
 list(APPEND PDAF_ENV_VARS TSMPPDAFLINK_LIBS=${PDAF_LINK_LIBS})
 list(APPEND PDAF_ENV_VARS TSMPPDAFOPTIM=${PDAF_OPTIM})
+list(APPEND PDAF_ENV_VARS TSMPPDAFDOUBLEPRECISION=${PDAF_DOUBLEPRECISION})
 list(APPEND PDAF_ENV_VARS TSMPPDAFMPI_INC=${PDAF_MPI_INC})
 list(APPEND PDAF_ENV_VARS TSMPPDAFCPP_DEFS=${PDAF_CPP_DEFS})
 


### PR DESCRIPTION
`TSMPPDAFDOUBLEPRECISION` is used for separating general optimization flags (`TSMPPDAFOPTIM`) from the flag setting float precision to double precision.

Goal: The float precision flag can then only be handed to the Fortran compiler.

## More info

For Intel compilers, the compiler flag `-r8` was before this PR saved in `TSMPPDAFOPTIM` and then set in `OPT` in PDAF's Makefile header `cmake.h`:

https://github.com/HPSCTerrSys/pdaf/blob/be688ebb6813a17a6f07bc8a60610d2fa0360733/make.arch/cmake.h#L39

 `OPT` is supplied to both Fortran and C compilers.

This lead to warnings like

```
icc: command line warning #10006: ignoring unknown option '-r8'
```

In `Stages/2024` on JSC machines, this warning turned into an error, prompting this PR.

