### PR TITLE
Add hidden module `pkgconf` to 2023-environment file

### DIFF
--- a/env/jsc.2023_Intel.sh
+++ b/env/jsc.2023_Intel.sh
@@ -23,6 +23,8 @@ module load NCO/5.1.3
 module load CMake/3.23.1
 module load git/2.36.0-nodocs  
 
+module load pkgconf/.1.8.0
+
 module li
 
 # Set default compilers


### PR DESCRIPTION
related to the Rocky Linux 9 update:
- https://status.jsc.fz-juelich.de/services/12#incident-864

This is a fix for Stages/2023, in Stages/2024 this fix should not be needed anymore.

Error message in CMake configuration:
```
CMake Error at /p/software/fs/juwels/stages/2023/software/CMake/3.23.1-GCCcore-11.3.0/share/cmake-3.23/Modules/FindPkgConfig.cmake:659 (message):
  pkg-config tool not found
```

@s-poll : I added a PR for this as just now there was the first time the error happened for a user.