### PR TITLE
build_tsmp2: correct check for alternative `parflow`

### DIFF
--- a/build_tsmp2.sh
+++ b/build_tsmp2.sh
@@ -66,7 +66,7 @@ local -n comp_namey=$1
 local -n comp_srcname=$2
 sub_srcname=$3
 if [ -n "${comp_namey}" ] && [ -z "${comp_srcname}" ];then
-  if [ "${comp_name}" = "parflow" ] && [ -n "${pdaf}" ];then
+  if [ "${sub_srcname}" = "parflow" ] && [ -n "${pdaf}" ];then
      submodule_name=$(echo "models/${sub_srcname}_pdaf")
   else
      submodule_name=$(echo "models/"${sub_srcname})


### PR DESCRIPTION
`sub_srcname` contains the string `parflow`, while `comp_name` takes the variable `parflow` that contains `y` or `n`.