### PR TITLE
LLVM Memory Sanitizer issues eCLM-PDAF

### DIFF
--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -99,7 +99,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
     list(APPEND PDAF_FOPT "-g")
     list(APPEND PDAF_FOPT "-traceback")
     list(APPEND PDAF_FOPT "-fpe0") # compare eCLM debug flags
-    list(APPEND PDAF_FOPT "-check all") # compare eCLM debug flags
+    # list(APPEND PDAF_FOPT "-check all") # compare eCLM debug flags
   else()
     message(FATAL_ERROR "Unsupported CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
   endif()


### PR DESCRIPTION
For eCLM-PDAF, specifying the debug compiler option `-check all` has lead to runtime errors related to the LLVM Memory Sanitizer (MSAN).

For now, this branch removing the compiler option is provided.

This will be investigated further in the future.

A more fine-grained analysis of the compiler options summarized under `-check all` could be needed. In particular the LLVM Memory Sanitizer (MSAN) is invoked by `-check uninit`. 

See https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2025-0/check.html