### PR TITLE
eCLM-ParFlowGPU fixes

### DIFF
--- a/env/jsc.2025.gnu.openmpi
+++ b/env/jsc.2025.gnu.openmpi
@@ -39,7 +39,7 @@ if [[ "$1" == "--parflowgpu" ]]; then
   #
   # RMM install script is at /p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/install_rmm.sh
   #
-  export RMM_ROOT="/p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/${SYSTEMNAME^^}_$STAGE"
+  export RMM_ROOT="/p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/rmm-0.10/${SYSTEMNAME^^}_$STAGE"
 
   # TODO: Verify these values
   if [[ $SYSTEMNAME == "jedi" ]]; then

--- a/env/jsc.2025.intel.psmpi
+++ b/env/jsc.2025.intel.psmpi
@@ -39,7 +39,7 @@ if [[ "$1" == "--parflowgpu" ]]; then
   #
   # RMM install script is at /p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/install_rmm.sh
   #
-  export RMM_ROOT="/p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/${SYSTEMNAME^^}_$STAGE"
+  export RMM_ROOT="/p/scratch/cslts/shared_data/TSMP2_S2025/RAPIDS_MemoryManager/rmm-0.10/${SYSTEMNAME^^}_$STAGE"
 
   # TODO: Verify these values
   if [[ $SYSTEMNAME == "jedi" ]]; then


### PR DESCRIPTION
*work-in-progress*

## Build commands

```bash
# Standalone ParFlow GPU
./build_tsmp2.sh --ParFlowGPU --clean_first --no_update --env env/jsc.2025.gnu.openmpi

# eCLM-ParFlowGPU
./build_tsmp2.sh --eCLM --ParFlowGPU --clean_first --no_update --env env/jsc.2025.gnu.openmpi
```

## Pre-built binaries

- [X] **JURECA** `/p/project1/cslts/rigor1/TSMP2/bin/TSMP2_S2025/JURECADC_ParFlowGPU`
- [X] **JUWELS** `/p/project1/cslts/rigor1/TSMP2/bin/TSMP2_S2025/JUWELS_eCLM-ParFlowGPU`
- [X] **JEDI** `/p/project1/cslts/rigor1/TSMP2/bin/TSMP2_S2025/JEDI_eCLM-ParFlowGPU`

## Model component git refs

- [HPSCTerrSys/eCLM/beta-0.2](https://github.com/HPSCTerrSys/eCLM/tree/beta-0.2)
- [HPSCTerrSys/parflow/cuda12-fixes](https://github.com/HPSCTerrSys/parflow/tree/cuda12-fixes)
