### PR TITLE
BuildPDAF: Safe adding of PDAF_MPI include directory

### DIFF
--- a/cmake/BuildPDAF.cmake
+++ b/cmake/BuildPDAF.cmake
@@ -220,7 +220,9 @@ list(JOIN PDAF_DOUBLEPRECISION " " PDAF_DOUBLEPRECISION)
 
 # Set PDAF_MPI_INC for Makefile header
 # ----------------------------------
-list(APPEND PDAF_MPI_INC "-I${MPICH_Fortran_INCLUDEDIR}")
+if(DEFINED MPICH_Fortran_INCLUDEDIR AND NOT MPICH_Fortran_INCLUDEDIR STREQUAL "")
+  list(APPEND PDAF_MPI_INC "-I${MPICH_Fortran_INCLUDEDIR}")
+endif()
 
 # Join list
 list(JOIN PDAF_MPI_INC " " PDAF_MPI_INC)


### PR DESCRIPTION
In particular: avoiding an isolated `-I` if `MPICH_Fortran_INCLUDEDIR` is undefined or empty.