### PR TITLE
Removed TSMP2_DIR variable from manual

### DIFF
--- a/docs/users_guide/building_TSMP2/Quickstart.md
+++ b/docs/users_guide/building_TSMP2/Quickstart.md
@@ -8,8 +8,7 @@
 
 ```bash
 git clone https://github.com/HPSCTerrSys/TSMP2.git
-export TSMP2_DIR=$(realpath TSMP2)
-cd $TSMP2_DIR
+cd TSMP2
 ```
 
 2. Build model components with TSMP2 framework


### PR DESCRIPTION
The shell variable `TSMP2_DIR` is not used by `build_tsmp2.sh`. One might get the impression that it has an effect on where the building takes place, but it does not.  To avoid unexpected behaviour and superfluous typing, let's remove it.